### PR TITLE
Include <algorithm> in ObserverManager.h so we can call std::find withou...

### DIFF
--- a/src/common/ObserverManager.h
+++ b/src/common/ObserverManager.h
@@ -6,6 +6,7 @@
 
 #include <mutex>
 #include <vector>
+#include <algorithm>
 
 namespace tools {
 


### PR DESCRIPTION
Include `<algorithm>` in ObserverManager.h so we can call std::find without a compiler error.

Fixes the build for me on Ubuntu 13.10.