### PR TITLE
Fixed hangup in Dispatcher::yield() in Linux

### DIFF
--- a/src/Platform/Linux/System/Dispatcher.cpp
+++ b/src/Platform/Linux/System/Dispatcher.cpp
@@ -329,6 +329,8 @@ void Dispatcher::yield() {
           contextPair->readContext->context->interruptProcedure = nullptr;
           pushContext(contextPair->readContext->context);
           contextPair->readContext->events = events[i].events;
+        } else if ((events[i].events & (EPOLLERR | EPOLLHUP)) != 0) {
+          throw std::runtime_error("Dispatcher::dispatch, events & (EPOLLERR | EPOLLHUP) != 0");
         } else {
           continue;
         }


### PR DESCRIPTION
It might enter into an infinite loop if epoll_wait begins to return
EPOLLERR|EPOLLHUP event mask.