### PR TITLE
Fix for issue #99

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -333,10 +333,10 @@ namespace Crypto {
     struct {
       EllipticCurvePoint a, b;
     } ab[];
-  };
+  } rsc;
 
   static inline size_t rs_comm_size(size_t pubs_count) {
-    return sizeof(rs_comm) + pubs_count * sizeof(rs_comm().ab[0]);
+    return sizeof(rs_comm) + pubs_count * sizeof(rsc.ab[0]);
   }
 
   void crypto_ops::generate_ring_signature(const Hash &prefix_hash, const KeyImage &image,


### PR DESCRIPTION
This will fix the size detection for the struct and make it run with boost 1.60 and above.