### PR TITLE
tx verification failed - change reporting level

### DIFF
--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -484,7 +484,7 @@ bool RpcServer::on_send_raw_tx(const COMMAND_RPC_SEND_RAW_TX::request& req, COMM
   logger(DEBUGGING) << "transaction " << transactionHash << " came in on_send_raw_tx";
 
   if (!m_core.addTransactionToPool(transactions.back())) {
-    logger(INFO) << "[on_send_raw_tx]: tx verification failed";
+    logger(DEBUGGING) << "[on_send_raw_tx]: tx verification failed";
     res.status = "Failed";
     return true;
   }


### PR DESCRIPTION
Until the method is finished, it will respond with "Tx verification failed" under normal conditions. It makes sense to log this as "DEBUGGING" rather than "INFO" until it can complete successfully or more gracefully.