### PR TITLE
Added reset param in CreateAddress method.

### DIFF
--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -148,7 +148,7 @@ public:
   virtual KeyPair getAddressSpendKey(const std::string& address) const = 0;
   virtual KeyPair getViewKey() const = 0;
   virtual std::string createAddress() = 0;
-  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey) = 0;
+  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey, bool reset = true) = 0;
   virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey) = 0;
   virtual std::vector<std::string> createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys) = 0;
   virtual void deleteAddress(const std::string& address) = 0;

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
@@ -69,6 +69,8 @@ void GetAddresses::Response::serialize(CryptoNote::ISerializer& serializer) {
 void CreateAddress::Request::serialize(CryptoNote::ISerializer& serializer) {
   bool hasSecretKey = serializer(spendSecretKey, "spendSecretKey");
   bool hasPublicKey = serializer(spendPublicKey, "spendPublicKey");
+  if (!serializer(reset, "reset"))
+	  reset = true;
 
   if (hasSecretKey && hasPublicKey) {
     //TODO: replace it with error codes

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.h
@@ -109,6 +109,7 @@ struct CreateAddress {
   struct Request {
     std::string spendSecretKey;
     std::string spendPublicKey;
+	bool reset;
 
     void serialize(CryptoNote::ISerializer& serializer);
   };

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
@@ -116,7 +116,7 @@ std::error_code PaymentServiceJsonRpcServer::handleCreateAddress(const CreateAdd
   if (request.spendSecretKey.empty() && request.spendPublicKey.empty()) {
     return service.createAddress(response.address);
   } else if (!request.spendSecretKey.empty()) {
-    return service.createAddress(request.spendSecretKey, response.address);
+    return service.createAddress(request.spendSecretKey, request.reset, response.address);
   } else {
     return service.createTrackingAddress(request.spendPublicKey, response.address);
   }

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -482,7 +482,7 @@ std::error_code WalletService::replaceWithNewWallet(const std::string& viewSecre
   return std::error_code();
 }
 
-std::error_code WalletService::createAddress(const std::string& spendSecretKeyText, std::string& address) {
+std::error_code WalletService::createAddress(const std::string& spendSecretKeyText, bool reset, std::string& address) {
   try {
     System::EventLock lk(readyEvent);
 
@@ -494,7 +494,7 @@ std::error_code WalletService::createAddress(const std::string& spendSecretKeyTe
       return make_error_code(CryptoNote::error::WalletServiceErrorCode::WRONG_KEY_FORMAT);
     }
 
-    address = wallet.createAddress(secretKey);
+    address = wallet.createAddress(secretKey, reset);
   } catch (std::system_error& x) {
     logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Error while creating address: " << x.what();
     return x.code();

--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -61,7 +61,7 @@ public:
   std::error_code exportWallet(const std::string& fileName);
   std::error_code resetWallet();
   std::error_code replaceWithNewWallet(const std::string& viewSecretKey);
-  std::error_code createAddress(const std::string& spendSecretKeyText, std::string& address);
+  std::error_code createAddress(const std::string& spendSecretKeyText, bool reset, std::string& address);
   std::error_code createAddressList(const std::vector<std::string>& spendSecretKeysText, std::vector<std::string>& addresses);
   std::error_code createAddress(std::string& address);
   std::error_code createTrackingAddress(const std::string& spendPublicKeyText, std::string& address);

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -946,14 +946,15 @@ std::string WalletGreen::createAddress() {
   return doCreateAddress(spendKey.publicKey, spendKey.secretKey, creationTimestamp);
 }
 
-std::string WalletGreen::createAddress(const Crypto::SecretKey& spendSecretKey) {
+std::string WalletGreen::createAddress(const Crypto::SecretKey& spendSecretKey, bool reset) {
   Crypto::PublicKey spendPublicKey;
   if (!Crypto::secret_key_to_public_key(spendSecretKey, spendPublicKey)) {
     m_logger(ERROR, BRIGHT_RED) << "createAddress(" << spendSecretKey << ") Failed to convert secret key to public key";
     throw std::system_error(make_error_code(CryptoNote::error::KEY_GENERATION_ERROR));
   }
+  uint64_t creationTimestamp = reset ? 0 : static_cast<uint64_t>(time(nullptr));
 
-  return doCreateAddress(spendPublicKey, spendSecretKey, 0);
+  return doCreateAddress(spendPublicKey, spendSecretKey, creationTimestamp);
 }
 
 std::string WalletGreen::createAddress(const Crypto::PublicKey& spendPublicKey) {

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -58,7 +58,7 @@ public:
   virtual KeyPair getAddressSpendKey(const std::string& address) const override;
   virtual KeyPair getViewKey() const override;
   virtual std::string createAddress() override;
-  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey) override;
+  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey, bool reset = true) override;
   virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey) override;
   virtual std::vector<std::string> createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys) override;
   virtual void deleteAddress(const std::string& address) override;

--- a/tests/UnitTests/TestWalletService.cpp
+++ b/tests/UnitTests/TestWalletService.cpp
@@ -68,7 +68,7 @@ struct IWalletBaseStub : public CryptoNote::IWallet, public CryptoNote::IFusionM
   virtual KeyPair getAddressSpendKey(const std::string& address) const override { return KeyPair(); }
   virtual KeyPair getViewKey() const override { return KeyPair(); }
   virtual std::string createAddress() override { return ""; }
-  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey) override { return ""; }
+  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey, bool reset) override { return ""; }
   virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey) override { return ""; }
   virtual std::vector<std::string> createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys) override { return std::vector<std::string>(); }
   virtual void deleteAddress(const std::string& address) override { }
@@ -205,7 +205,7 @@ struct WalletCreateAddressStub: public IWalletBaseStub {
   WalletCreateAddressStub(System::Dispatcher& d) : IWalletBaseStub(d) {}
 
   virtual std::string createAddress() override { return address; }
-  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey) override { return address; }
+  virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey, bool reset) override { return address; }
   virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey) override { return address; }
 
   std::string address = "correctAddress";
@@ -226,7 +226,7 @@ TEST_F(WalletServiceTest_createAddress, invalidSecretKey) {
   std::unique_ptr<WalletService> service = createWalletService();
 
   std::string address;
-  std::error_code ec = service->createAddress("wrong key", address);
+  std::error_code ec = service->createAddress("wrong key", true, address);
   ASSERT_EQ(make_error_code(CryptoNote::error::WalletServiceErrorCode::WRONG_KEY_FORMAT), ec);
 }
 
@@ -247,7 +247,7 @@ TEST_F(WalletServiceTest_createAddress, correctSecretKey) {
   std::unique_ptr<WalletService> service = createWalletService(wallet);
 
   std::string address;
-  std::error_code ec = service->createAddress(Common::podToHex(sec), address);
+  std::error_code ec = service->createAddress(Common::podToHex(sec), true, address);
 
   ASSERT_FALSE(ec);
   ASSERT_EQ(wallet.address, address);


### PR DESCRIPTION
Determines whether reset wallet or not on address creation with spendKey. By default is true - do reset (old behavior). This can be useful for exchanges.